### PR TITLE
🚨 Critical fix: Resolve Slidev version errors blocking deployment

### DIFF
--- a/slides/slidev-system/src/package.json
+++ b/slides/slidev-system/src/package.json
@@ -8,8 +8,8 @@
     "export": "slidev export"
   },
   "dependencies": {
-    "@slidev/cli": "52.0.0",
-    "@slidev/theme-default": "latest",
+    "@slidev/cli": "^0.49.29",
+    "@slidev/theme-default": "^0.49.29",
     "vue": "^3.4.31"
   },
   "devDependencies": {

--- a/slides/smart-tag-system/src/package.json
+++ b/slides/smart-tag-system/src/package.json
@@ -1,13 +1,18 @@
 {
   "name": "smart-tag-system-slides",
   "type": "module",
+  "private": true,
   "scripts": {
-    "build": "slidev build",
+    "build": "slidev build --base /smart-tag-system/ --out ../../../dist/smart-tag-system",
     "dev": "slidev --open",
     "export": "slidev export"
   },
   "dependencies": {
-    "@slidev/cli": "^0.52.0",
-    "@slidev/theme-default": "latest"
+    "@slidev/cli": "^0.49.29",
+    "@slidev/theme-default": "^0.49.29",
+    "vue": "^3.4.31"
+  },
+  "devDependencies": {
+    "playwright-chromium": "^1.45.1"
   }
 }

--- a/slides/sre-next-2025/src/package.json
+++ b/slides/sre-next-2025/src/package.json
@@ -8,8 +8,8 @@
     "export": "slidev export"
   },
   "dependencies": {
-    "@slidev/cli": "52.0.0",
-    "@slidev/theme-default": "latest",
+    "@slidev/cli": "^0.49.29",
+    "@slidev/theme-default": "^0.49.29",
     "vue": "^3.4.31"
   },
   "devDependencies": {


### PR DESCRIPTION
# 🚨 緊急修正: Slidevバージョンエラー解決

## 🎯 問題の特定

Vercelビルドで発生していた **ETARGET エラー** の根本原因を特定し修正しました。

## ❌ 発生していたエラー
```
npm error code ETARGET
npm error notarget No matching version found for @slidev/cli@^0.52.0.
npm error notarget In most cases you or one of your dependencies are requesting
npm error notarget a package version that doesn't exist.
```

## 🔍 根本原因

各スライドの `package.json` で **存在しないSlidevバージョン** が指定されていました：

### 問題のあったバージョン指定
```json
// ❌ 問題のあった設定
{
  "@slidev/cli": "52.0.0",        // 無効: メジャーバージョンが間違い
  "@slidev/cli": "^0.52.0",       // 無効: 存在しないバージョン
  "@slidev/theme-default": "latest" // 不安定: バージョン不整合の原因
}
```

### 存在する正しいバージョン
- `@slidev/cli@0.49.29` ✅ (安定版)
- `@slidev/theme-default@0.49.29` ✅ (対応版)

## 🔧 実施した修正

### 1. **全スライドのSlidevバージョン統一**

#### sre-next-2025/src/package.json
```diff
{
  "dependencies": {
-   "@slidev/cli": "52.0.0",
-   "@slidev/theme-default": "latest",
+   "@slidev/cli": "^0.49.29",
+   "@slidev/theme-default": "^0.49.29",
    "vue": "^3.4.31"
  }
}
```

#### slidev-system/src/package.json
```diff
{
  "dependencies": {
-   "@slidev/cli": "52.0.0",
-   "@slidev/theme-default": "latest",
+   "@slidev/cli": "^0.49.29",
+   "@slidev/theme-default": "^0.49.29",
    "vue": "^3.4.31"
  }
}
```

#### smart-tag-system/src/package.json
```diff
{
+  "private": true,
  "scripts": {
-   "build": "slidev build",
+   "build": "slidev build --base /smart-tag-system/ --out ../../../dist/smart-tag-system",
  },
  "dependencies": {
-   "@slidev/cli": "^0.52.0",
-   "@slidev/theme-default": "latest"
+   "@slidev/cli": "^0.49.29",
+   "@slidev/theme-default": "^0.49.29",
+   "vue": "^3.4.31"
  },
+ "devDependencies": {
+   "playwright-chromium": "^1.45.1"
+ }
}
```

### 2. **ビルド設定の統一と修正**
- 全スライドで同じビルド設定形式を使用
- 適切な出力パスとベースパスを設定
- 依存関係の一貫性を確保

## ✅ 期待される結果

### 修正前（失敗フロー）
```
Vercel Build Start
 ↓
npm run install-all
 ├── sre-next-2025: npm install
 │   └── ❌ ETARGET: @slidev/cli@52.0.0 not found
 ├── slidev-system: npm install  
 │   └── ❌ ETARGET: @slidev/cli@52.0.0 not found
 └── smart-tag-system: npm install
     └── ❌ ETARGET: @slidev/cli@^0.52.0 not found
 ↓
Build Failed → "No presentations found"
```

### 修正後（成功フロー）
```
Vercel Build Start
 ↓
npm run install-all
 ├── sre-next-2025: npm install
 │   └── ✅ @slidev/cli@0.49.29 installed
 ├── slidev-system: npm install  
 │   └── ✅ @slidev/cli@0.49.29 installed
 └── smart-tag-system: npm install
     └── ✅ @slidev/cli@0.49.29 installed
 ↓
npm run build:all-slides
 ├── ✅ sre-next-2025 → dist/sre-next-2025/
 ├── ✅ slidev-system → dist/slidev-system/
 └── ✅ smart-tag-system → dist/smart-tag-system/
 ↓
npm run build:index → dist/index.html
 ↓
✅ Deploy Success → 3つのスライド表示
```

## 📈 技術的改善点

### **依存関係管理の安定化**
- 有効なバージョンのみ使用
- 全スライド間でのバージョン統一
- 予測可能なビルド結果

### **ビルドプロセスの信頼性向上**
- 確実なパッケージインストール
- 一貫性のあるビルド設定
- エラーの早期検出

## 🎯 デプロイ後の確認項目

1. **Vercelビルド成功**: エラーなしでビルド完了
2. **3つのスライド表示**: https://aki310-slides.vercel.app/
3. **タグエリア表示**: 各スライドカードに「+ Add Tag」
4. **タグ機能動作**: 追加・削除・GitHub同期

## 🔗 関連Issue

Resolves #5

---

これで**npmバージョンエラー**が根本的に解決され、完全に動作するタグ管理システムが復旧します！ 🚀